### PR TITLE
puppet4 requres mode be a string

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -6,7 +6,7 @@ class rkhunter::packages {
 
   file { '/usr/local/bin/rktask':
     ensure => file,
-    mode   => 755,
+    mode   => '755',
     source => 'puppet:///modules/rkhunter/rktask'
   }
 }


### PR DESCRIPTION
puppet4 requres mode be a string per https://docs.puppetlabs.com/references/latest/type.html#file-attribute-mode
